### PR TITLE
Add Consensus actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ Datawow.[class].find_by({id: "_image_id", token: '_token'})
 ```ruby
 Datawow.[class].all({token: '_token'})
 ```
+---
+## Nanameue with Consensus
+#### `create`
+```ruby
+Datawow::NanameueHuman.new(token: '_token').create({data: "image URL"})
+```
+
+#### `find_by`
+```ruby
+Datawow::NanameueHuman.new(token: '_token').find_by({id: "_image_id"})
+```
+
+#### `all`
+```ruby
+Datawow::NanameueHuman.new(token: '_token').all({page: '_page', per_page: '_per_page'})
+```
 
 # Setting default token
 

--- a/README.md
+++ b/README.md
@@ -78,17 +78,17 @@ Datawow.[class].all({token: '_token'})
 ## Nanameue with Consensus
 #### `create`
 ```ruby
-Datawow::NanameueHuman.new(token: '_token').create({data: "image URL"})
+Datawow::NanameueHuman.new('_token').create({data: "image URL"})
 ```
 
 #### `find_by`
 ```ruby
-Datawow::NanameueHuman.new(token: '_token').find_by({id: "_image_id"})
+Datawow::NanameueHuman.new('_token').find_by({id: "_image_id"})
 ```
 
 #### `all`
 ```ruby
-Datawow::NanameueHuman.new(token: '_token').all({page: '_page', per_page: '_per_page'})
+Datawow::NanameueHuman.new('_token').all({page: '_page', per_page: '_per_page'})
 ```
 
 # Setting default token

--- a/lib/datawow.rb
+++ b/lib/datawow.rb
@@ -22,7 +22,7 @@ require_relative 'datawow/models/videos/video_classifications'
 
 # :nodoc:
 module Datawow
-  module_function
+  extend self
 
   attr_accessor :project_key
 

--- a/lib/datawow.rb
+++ b/lib/datawow.rb
@@ -12,6 +12,7 @@ require_relative 'datawow/models/images/image_closed_questions'
 require_relative 'datawow/models/images/image_photo_tags'
 require_relative 'datawow/models/images/image_choices'
 require_relative 'datawow/models/images/image_messages'
+require_relative 'datawow/models/images/nanameue_human'
 require_relative 'datawow/models/predictions/predictors'
 
 require_relative 'datawow/models/texts/text_categories'
@@ -65,6 +66,10 @@ module Datawow
 
     def prediction
       Predictor.new
+    end
+
+    def nanameue_human
+      NanameueHuman.new
     end
   end
 end

--- a/lib/datawow/client_response.rb
+++ b/lib/datawow/client_response.rb
@@ -5,7 +5,7 @@ module Datawow
 
     def initialize(data, response_code = '', response_message = 'success', meta = nil, total = 0)
       @data = data
-      @status = response_code
+      @status = response_code.to_i
       @message = response_message
       @meta = meta
       @total = total unless total.nil?

--- a/lib/datawow/connector.rb
+++ b/lib/datawow/connector.rb
@@ -20,6 +20,7 @@ module Datawow
     def post(data = {})
       @method = :POST
       response = send_request(data)
+
       body = JSON.parse response.body
 
       Response.new(body['data'], response.code, body['meta']['message'], body['meta'], 1)
@@ -74,7 +75,7 @@ module Datawow
 
     def build_request(uri)
       request = {}
-      token = if Datawow.respond_to?(:project_key)
+      token = if Datawow.project_key
                 Datawow.project_key
               else
                 @token

--- a/lib/datawow/models/images/nanameue_human.rb
+++ b/lib/datawow/models/images/nanameue_human.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Datawow
+  # :nodoc:
+  class NanameueHuman
+    include Datawow::Models::Interface
+
+    attr_writer :token
+
+    def initialize(token = nil)
+      @token = token
+      @type = :image
+      @path = 'jobs/nanameue/consensuses'
+    end
+  end
+end

--- a/test/datawow/connection_test.rb
+++ b/test/datawow/connection_test.rb
@@ -18,7 +18,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'Internal Server Error', code: 500 }), status: 500)
       response = connection.get('/images', {})
       assert_instance_of(Response, response)
-      assert_equal('500', response.status)
+      assert_equal(500, response.status)
     end
 
     def test_post_success
@@ -34,7 +34,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { code: 500, message: 'Internal Server Error' }), status: 500)
       response = connection.post('/images', {})
       assert_instance_of(Response, response)
-      assert_equal('500', response.status)
+      assert_equal(500, response.status)
     end
 
     def test_connection_failed
@@ -49,7 +49,7 @@ module Datawow
         .to_return(status: 400, body: JSON.generate(data: '', meta: { message: 'bad request', code: 400 }))
       response = connection.get('/images', {})
       assert_instance_of(Response, response)
-      assert_equal('400', response.status)
+      assert_equal(400, response.status)
     end
 
     def test_forbidden_status
@@ -57,7 +57,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'forbidden', code: 403 }), status: 403)
       response = connection.get('/images', {})
       assert_instance_of(Response, response)
-      assert_equal('403', response.status)
+      assert_equal(403, response.status)
     end
 
     def test_not_found_status
@@ -65,7 +65,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'not found', code: 404 }), status: 404)
       response = connection.get('/images', {})
       assert_instance_of(Response, response)
-      assert_equal('404', response.status)
+      assert_equal(404, response.status)
     end
 
     def test_edge_case_error
@@ -73,7 +73,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'version not supported', code: 505 }), status: 505)
       response = connection.get('/images', {})
       assert_instance_of(Response, response)
-      assert_equal('505', response.status)
+      assert_equal(505, response.status)
     end
 
     private

--- a/test/datawow/connector_test.rb
+++ b/test/datawow/connector_test.rb
@@ -9,7 +9,7 @@ module Datawow
         .to_return(body: JSON.generate(data: 'foo', meta: { message: 'success', code: 200 }), status: 200)
       response = connector.get
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       assert_equal('success', response.message)
       assert_equal('success', response.meta['message'])
     end
@@ -19,7 +19,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'Internal Server Error', code: 500 }), status: 500)
       response = connector.get
       assert_instance_of(Response, response)
-      assert_equal('500', response.status)
+      assert_equal(500, response.status)
     end
 
     def test_post_success
@@ -27,7 +27,7 @@ module Datawow
         .to_return(body: JSON.generate(data: 'foo', meta: { code: 200 }), status: 200)
       response = connector.post
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
     end
 
     def test_post_failed
@@ -35,7 +35,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { code: 500, message: 'Internal Server Error' }), status: 500)
       response = connector.post
       assert_instance_of(Response, response)
-      assert_equal('500', response.status)
+      assert_equal(500, response.status)
     end
 
     def test_bad_request_status
@@ -43,7 +43,7 @@ module Datawow
         .to_return(status: 400, body: JSON.generate(data: '', meta: { message: 'bad request', code: 400 }))
       response = connector.get
       assert_instance_of(Response, response)
-      assert_equal('400', response.status)
+      assert_equal(400, response.status)
     end
 
     def test_forbidden_status
@@ -51,7 +51,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'forbidden', code: 403 }), status: 403)
       response = connector.get
       assert_instance_of(Response, response)
-      assert_equal('403', response.status)
+      assert_equal(403, response.status)
     end
 
     def test_not_found_status
@@ -59,7 +59,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'not found', code: 404 }), status: 404)
       response = connector.get
       assert_instance_of(Response, response)
-      assert_equal('404', response.status)
+      assert_equal(404, response.status)
     end
 
     def test_edge_case_error
@@ -67,7 +67,7 @@ module Datawow
         .to_return(body: JSON.generate(data: '', meta: { message: 'version not supported', code: 505 }), status: 505)
       response = connector.get
       assert_instance_of(Response, response)
-      assert_equal('505', response.status)
+      assert_equal(505, response.status)
     end
 
     private

--- a/test/datawow/image_choices_test.rb
+++ b/test/datawow/image_choices_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id: 'test')
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/image_closed_questions_test.rb
+++ b/test/datawow/image_closed_questions_test.rb
@@ -9,7 +9,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -20,7 +20,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -31,7 +31,7 @@ module Datawow
       response = model.find_by(id: 'test')
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/image_messages_test.rb
+++ b/test/datawow/image_messages_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id: 'test')
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/image_photo_tags_test.rb
+++ b/test/datawow/image_photo_tags_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id: 'test')
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/nanameue_human_test.rb
+++ b/test/datawow/nanameue_human_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Datawow
+  class NanameueHumanTest < TestBase
+    def test_all
+      stub_request(:get, NANAMEUE_HUMAN_URL)
+        .to_return(body: JSON.generate(nanameue_humen), status: 200)
+      response = model.all
+
+      assert_instance_of(Response, response)
+      assert_equal(200, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    def test_create
+      stub_request(:post, NANAMEUE_HUMAN_URL)
+        .to_return(body: JSON.generate(nanameue_human), status: 201)
+      response = model.create(options)
+
+      assert_instance_of(Response, response)
+      assert_equal(201, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    def test_find
+      stub_request(:get, "#{NANAMEUE_HUMAN_URL}?id=test")
+        .to_return(body: JSON.generate(nanameue_human), status: 200)
+      response = model.find_by(id: 'test')
+
+      assert_instance_of(Response, response)
+      assert_equal(200, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    private
+
+    def model
+      @model ||= NanameueHuman.new
+      @model.token = 'test'
+      @model
+    end
+  end
+end

--- a/test/datawow/nanameue_human_test.rb
+++ b/test/datawow/nanameue_human_test.rb
@@ -5,7 +5,7 @@ module Datawow
   class NanameueHumanTest < TestBase
     def test_all
       stub_request(:get, NANAMEUE_HUMAN_URL)
-        .to_return(body: JSON.generate(nanameue_humen), status: 200)
+        .to_return(body: JSON.generate(nanameue_humans), status: 200)
       response = model.all
 
       assert_instance_of(Response, response)

--- a/test/datawow/predictors_test.rb
+++ b/test/datawow/predictors_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id: '1')
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/text_categories_test.rb
+++ b/test/datawow/text_categories_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id: '1')
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/text_closed_questions_test.rb
+++ b/test/datawow/text_closed_questions_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id: '1')
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/text_conversations_test.rb
+++ b/test/datawow/text_conversations_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id:1)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/datawow/video_classifications_test.rb
+++ b/test/datawow/video_classifications_test.rb
@@ -10,7 +10,7 @@ module Datawow
       response = model.all
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -21,7 +21,7 @@ module Datawow
       response = model.create(options)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end
@@ -32,7 +32,7 @@ module Datawow
       response = model.find_by(id: 1)
 
       assert_instance_of(Response, response)
-      assert_equal('200', response.status)
+      assert_equal(200, response.status)
       refute_nil(response.data)
       refute_nil(response.meta)
     end

--- a/test/fixtures/nanameue_human/all.json
+++ b/test/fixtures/nanameue_human/all.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "images": [
+      {
+        "id": "5c218fcc1eda3f457430ee45",
+        "answer": "approved",
+        "credit_charged": 0,
+        "custom_id": null,
+        "data": "data",
+        "mode": "human",
+        "created_at": "2018-12-25T09:02:52.650+07:00",
+        "postback": true,
+        "postback_url": "https://datawow.io",
+        "processed_at": "2018-12-28T12:30:06.415+07:00",
+        "project_id": 199,
+        "staff_id": null,
+        "status": "processed"
+      }
+    ]
+  },
+  "meta": {
+    "code": 200,
+    "message": "success"
+  }
+}

--- a/test/fixtures/nanameue_human/create.json
+++ b/test/fixtures/nanameue_human/create.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "id": "5c218fcc1eda3f457430ee45",
+    "answer": null,
+    "credit_charged": 0,
+    "custom_id": null,
+    "data": "data",
+    "mode": "human",
+    "created_at": "2018-12-25T09:02:52.650+07:00",
+    "postback": true,
+    "postback_url": "https://datawow.io",
+    "processed_at": null,
+    "project_id": 199,
+    "staff_id": null,
+    "status": "unprocess"
+  },
+  "meta": {
+    "code": 201,
+    "message": "created success"
+  }
+}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ class TestBase < Minitest::Test
               :image_closed_questions, :image_message, :image_messages, :image_photo_tag,
               :image_photo_tags, :prediction, :predictions, :videos, :video,
               :text_categories, :text_category, :text_conversations, :text_conversation,
-              :text_closed_questions, :text_closed_question
+              :text_closed_questions, :text_closed_question, :nanameue_human, :nanameue_humen
 
   IMAGE_CHOICES_URL          = 'https://kiyo-image.datawow.io/api/v1/images/choices'.freeze
   IMAGE_CHOICE_URL           = 'https://kiyo-image.datawow.io/api/v1/images/choice'.freeze
@@ -26,6 +26,7 @@ class TestBase < Minitest::Test
   PREDICTIONS_URL            = 'https://kiyo-image.datawow.io/api/v1/prime/predictions'.freeze
   IMAGE_URL                  = 'https://kiyo-image.datawow.io/api/v1/projects/images'.freeze
   VIDEO_URL                  = 'https://kiyo-image.datawow.io/api/v1/videos/closed_questions'.freeze
+  NANAMEUE_HUMAN_URL         = 'https://kiyo-image.datawow.io/api/v1/jobs/nanameue/consensuses'.freeze
   TEXT_CATEGORY_URL          = 'https://kiyo-text.datawow.io/api/v1/text/text_categories'.freeze
   TEXT_CONVERSATION_URL      = 'https://kiyo-text.datawow.io/api/v1/text/text_conversations'.freeze
   TEXT_CLOSED_QUESTION_URL   = 'https://kiyo-text.datawow.io/api/v1/text/text_closed_questions'.freeze
@@ -43,6 +44,8 @@ class TestBase < Minitest::Test
     @prediction             = FileReader.new('test/fixtures/prediction/create.json').read_json
     @videos                 = FileReader.new('test/fixtures/video_classification/all.json').read_json
     @video                  = FileReader.new('test/fixtures/video_classification/create.json').read_json
+    @nanameue_human         = FileReader.new('test/fixtures/nanameue_human/create.json').read_json
+    @nanameue_humen         = FileReader.new('test/fixtures/nanameue_human/all.json').read_json
     @text_category          = FileReader.new('test/fixtures/text_category/create.json').read_json
     @text_categories        = FileReader.new('test/fixtures/text_category/all.json').read_json
     @text_conversation      = FileReader.new('test/fixtures/text_conversation/create.json').read_json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ class TestBase < Minitest::Test
               :image_closed_questions, :image_message, :image_messages, :image_photo_tag,
               :image_photo_tags, :prediction, :predictions, :videos, :video,
               :text_categories, :text_category, :text_conversations, :text_conversation,
-              :text_closed_questions, :text_closed_question, :nanameue_human, :nanameue_humen
+              :text_closed_questions, :text_closed_question, :nanameue_human, :nanameue_humans
 
   IMAGE_CHOICES_URL          = 'https://kiyo-image.datawow.io/api/v1/images/choices'.freeze
   IMAGE_CHOICE_URL           = 'https://kiyo-image.datawow.io/api/v1/images/choice'.freeze
@@ -45,7 +45,7 @@ class TestBase < Minitest::Test
     @videos                 = FileReader.new('test/fixtures/video_classification/all.json').read_json
     @video                  = FileReader.new('test/fixtures/video_classification/create.json').read_json
     @nanameue_human         = FileReader.new('test/fixtures/nanameue_human/create.json').read_json
-    @nanameue_humen         = FileReader.new('test/fixtures/nanameue_human/all.json').read_json
+    @nanameue_humans        = FileReader.new('test/fixtures/nanameue_human/all.json').read_json
     @text_category          = FileReader.new('test/fixtures/text_category/create.json').read_json
     @text_categories        = FileReader.new('test/fixtures/text_category/all.json').read_json
     @text_conversation      = FileReader.new('test/fixtures/text_conversation/create.json').read_json


### PR DESCRIPTION
This PR adds Consensus actions with Nanameue predictor to the library.

There are 3 available actions, `create`, `find_by` and `find_all`. The example can be found in Readme.