### PR TITLE
Add Text AI Japanese actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,14 @@ Datawow.nanameue_human.all({page: '_page', per_page: '_per_page'})
 ---
 
 ## Text AI Japanese
-#### `create`
-
+##### Set your project key
 ```ruby
-Datawow.text_ja.create({ data: 'フーバーバズ' })
+Datawow.project_key = '_token'
+```
+
+#### `create`
+```ruby
+Datawow.text_ja.create({ data: 'フーバーバズ', custom_id: 'custom_id', postback_method: 'GET', postback_url: 'https://datawow.io' })
 ```
 
 #### `find_by`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ There are 3 APIs for text class
 Datawow.text_closed_question
 Datawow.text_category
 Datawow.text_conversation
+Datawow.text_ja
 ```
 ---
 
@@ -76,7 +77,7 @@ Datawow.[class].all({token: '_token'})
 ```
 ---
 ## Nanameue with Consensus
-##### There are 2 ways to use the library 
+##### There are 2 ways to use the library
 
 Firstly, __dynamic token__. if you have multiple project to work with, You could call library by using module name
 #### `create`
@@ -107,7 +108,7 @@ Secondly, we have initiated each modules since the library being called, so you 
 ```ruby
 Datawow.project_key = '_token'
 ```
-##### Start workgin with a provieded method
+##### Start working with provided methods
 #### `create`
 ```ruby
 Datawow.nanameue_human.create({data: "image URL"})
@@ -121,6 +122,24 @@ Datawow.nanameue_human.find_by({id: "_image_id"})
 #### `all`
 ```ruby
 Datawow.nanameue_human.all({page: '_page', per_page: '_per_page'})
+```
+---
+
+## Text AI Japanese
+#### `create`
+
+```ruby
+Datawow.text_ja.create({ data: 'フーバーバズ' })
+```
+
+#### `find_by`
+```ruby
+Datawow.text_ja.find_by({ id: '_text_id' })
+```
+
+#### `all`
+```ruby
+Datawow.text_ja.all({page: '_page', per_page: '_per_page'})
 ```
 
 # Setting default token

--- a/lib/datawow.rb
+++ b/lib/datawow.rb
@@ -15,6 +15,7 @@ require_relative 'datawow/models/predictions/predictors'
 require_relative 'datawow/models/texts/text_categories'
 require_relative 'datawow/models/texts/text_closed_questions'
 require_relative 'datawow/models/texts/text_conversations'
+require_relative 'datawow/models/texts/text_ja'
 
 require_relative 'datawow/models/videos/video_classifications'
 
@@ -43,6 +44,10 @@ module Datawow
 
     def text_conversation
       TextConversation.new
+    end
+
+    def text_ja
+      TextJa.new
     end
 
     def image_closed_question

--- a/lib/datawow/models/texts/text_ja.rb
+++ b/lib/datawow/models/texts/text_ja.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Datawow
+  # :nodoc:
+  class TextJa
+    include Datawow::Models::Interface
+
+    attr_writer :project_key
+
+    def initialize(token = nil)
+      @project_key = token
+      @type = :text
+      @query_str = false
+      @path = 'text_ai/text_ja'
+    end
+  end
+end

--- a/test/datawow/text_ja_test.rb
+++ b/test/datawow/text_ja_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Datawow
+  class TextJaTest < TestBase
+    def test_all
+      stub_request(:get, TEXT_JA_URL)
+        .to_return(body: JSON.generate(text_jas), status: 200)
+      response = model.all
+
+      assert_instance_of(Response, response)
+      assert_equal(200, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    def test_create
+      stub_request(:post, TEXT_JA_URL)
+        .to_return(body: JSON.generate(text_jas), status: 201)
+      response = model.create(options)
+
+      assert_instance_of(Response, response)
+      assert_equal(201, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    def test_find
+      stub_request(:get, "#{TEXT_JA_URL}/1")
+        .to_return(body: JSON.generate(text_ja), status: 200)
+      response = model.find_by(id: '1')
+
+      assert_instance_of(Response, response)
+      assert_equal(200, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    private
+
+    def model
+      @model ||= TextJa.new
+      @model.project_key = 'test'
+      @model
+    end
+  end
+end

--- a/test/fixtures/text_ja/all.json
+++ b/test/fixtures/text_ja/all.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "id": "5c2eb38f0df256348de69a1f",
+      "created_at": "2019-01-04T08:14:55.372+07:00",
+      "custom_id": null,
+      "data": "foobar",
+      "processed_at": "2019-01-04T08:14:55.371+07:00",
+      "project_id": 202,
+      "results": {
+        "declined": 0.001,
+        "developing_model": {
+          "approved": 0.9909,
+          "pros-sexual": 0.0046,
+          "sns": 0.045
+        },
+        "pros_fasttext": 0.001,
+        "sexual_fasttext": 0.001,
+        "sexual_fasttext_romanji": 0.001,
+        "sns_fasttext": 0.001
+      },
+      "staff_id": 999998,
+      "status": "done"
+    }
+  ],
+  "meta": {
+    "code": 200,
+    "message": "success",
+    "current_page": 1,
+    "next_page": -1,
+    "prev_page": -1,
+    "total_pages": 1,
+    "total_count": 2
+  }
+}

--- a/test/fixtures/text_ja/create.json
+++ b/test/fixtures/text_ja/create.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "id": "5c2eb38f0df256348de69a1f",
+    "created_at": "2019-01-04T08:14:55.372+07:00",
+    "custom_id": null,
+    "data": "foobar",
+    "processed_at": "2019-01-04T08:14:55.371+07:00",
+    "project_id": 202,
+    "results": {
+      "declined": 0.001,
+      "developing_model": {
+        "approved": 0.9909,
+        "pros-sexual": 0.0046,
+        "sns": 0.045
+      },
+      "pros_fasttext": 0.001,
+      "sexual_fasttext": 0.001,
+      "sexual_fasttext_romanji": 0.001,
+      "sns_fasttext": 0.001
+    },
+    "staff_id": 999998,
+    "status": "done"
+  },
+  "meta": {
+    "code": 201,
+    "message": "success"
+  }
+}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,8 @@ class TestBase < Minitest::Test
               :image_closed_questions, :image_message, :image_messages, :image_photo_tag,
               :image_photo_tags, :prediction, :predictions, :videos, :video,
               :text_categories, :text_category, :text_conversations, :text_conversation,
-              :text_closed_questions, :text_closed_question, :nanameue_human, :nanameue_humans
+              :text_closed_questions, :text_closed_question, :nanameue_human, :nanameue_humans,
+              :text_ja, :text_jas
 
   IMAGE_CHOICES_URL          = 'https://kiyo-image.datawow.io/api/v1/images/choices'.freeze
   IMAGE_CHOICE_URL           = 'https://kiyo-image.datawow.io/api/v1/images/choice'.freeze
@@ -30,6 +31,7 @@ class TestBase < Minitest::Test
   TEXT_CATEGORY_URL          = 'https://kiyo-text.datawow.io/api/v1/text/text_categories'.freeze
   TEXT_CONVERSATION_URL      = 'https://kiyo-text.datawow.io/api/v1/text/text_conversations'.freeze
   TEXT_CLOSED_QUESTION_URL   = 'https://kiyo-text.datawow.io/api/v1/text/text_closed_questions'.freeze
+  TEXT_JA_URL                = 'https://kiyo-text.datawow.io/api/v1/text_ai/text_ja'.freeze
 
   def setup
     @image_choices          = FileReader.new('test/fixtures/image_choice/all.json').read_json
@@ -52,6 +54,8 @@ class TestBase < Minitest::Test
     @text_conversations     = FileReader.new('test/fixtures/text_conversation/all.json').read_json
     @text_closed_question   = FileReader.new('test/fixtures/text_closed_question/create.json').read_json
     @text_closed_questions  = FileReader.new('test/fixtures/text_closed_question/all.json').read_json
+    @text_ja                = FileReader.new('test/fixtures/text_ja/create.json').read_json
+    @text_jas               = FileReader.new('test/fixtures/text_ja/all.json').read_json
     @options = {
       token: 'project token'
     }


### PR DESCRIPTION
This PR adds Text AI Japanese actions.

There are 3 available actions, `create`, `find_by` and `all`. The example can be found in Readme.