### PR TITLE
feat: Update Document Verifications calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 datawow-*
+tags

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To call our module, use `Datawow` followed by any of the classes provided in our
 These classes are instance methods we have created for you. You can use our provider or the recommended methods, [here](#dynamically_token_setting), when using our APIs
 
 #### Image classes `Datawow.image_*`
-There are 4 APIs for image class
+There are 6 APIs for image class
 
 ## instance method
 ```ruby
@@ -33,6 +33,7 @@ Datawow.image_photo_tag
 Datawow.image_choice
 Datawow.image_message
 Datawow.nanameue_human
+Datawow.document_verification
 ```
 ---
 
@@ -44,7 +45,7 @@ Datawow.video_classification
 ```
 ---
 #### Text classe `Datawow.text_*`
-There are 3 APIs for text class
+There are 4 APIs for text class
 
 ```ruby
 Datawow.text_closed_question
@@ -75,6 +76,7 @@ Datawow::TextCategory
 Datawow::TextConversation
 Datawow::TextJa
 Datawow::Prediction
+Datawow::DocumentVerification
 ```
 ---
 ## Available methods in our APIs

--- a/README/image_docs.md
+++ b/README/image_docs.md
@@ -101,14 +101,14 @@ payload = {
   data: <document-image-url>,
   infos: {
     type: {
-      value: <customer-card-type> # - The customer card's type. e.g. "student card", "ID card"
+      value: <document-type> # - The document's type. e.g. "student card", "ID card", "Passport"
     },
     dob: {
-      value: <customer-date-of-birth> # - The customer date of birth. Should be in format like `YYYY-MM-DD`.
+      value: <customer-date-of-birth> # - The customer's date of birth. Should be in format like `YYYY-MM-DD`.
     }
   },
-  postback_method: "GET", # - The HTTP methods for posting result back to customer.
-  postback_url: <customer-postback-url> # - The customer's endpoint url receives result after verification success.
+  postback_method: "GET", # - The HTTP method for posting result back to customer.
+  postback_url: <customer-postback-url> # - The customer's endpoint url receives result after verified success.
 }
 
 Datawow.project_key = <project-token>

--- a/README/image_docs.md
+++ b/README/image_docs.md
@@ -92,6 +92,45 @@ Description: Identifying an object in the image (60 mins response time) - This m
 |custom_id|string|No|Custom ID that used for search|
 
 ---
+
+## Document Verification
+
+### Create
+```ruby
+payload = {
+  data: <document-image-url>,
+  infos: {
+    type: {
+      value: <customer-card-type> # - The customer card's type. e.g. "student card", "ID card"
+    },
+    dob: {
+      value: <customer-date-of-birth> # - The customer date of birth. Should be in format like `YYYY-MM-DD`.
+    }
+  },
+  postback_method: "GET", # - The HTTP methods for posting result back to customer.
+  postback_url: <customer-postback-url> # - The customer's endpoint url receives result after verification success.
+}
+
+Datawow.project_key = <project-token>
+Datawow.document_verification.create(payload)
+```
+
+#### params
+| Field | Type| Required | Description |
+| ------------- |:-------------:| :-----:| :-----|
+|data| string|**Yes** |URL of image|
+|infos| Hash| **Yes** |Hash of document's informations|
+|postback_url|string| No |URL to receive result once document has been verified|
+|postback_method|string | No |Configuration HTTP method GET POST PUT PATCH|
+|custom_id|string|No|Custom ID that used for search|
+
+### Search
+```ruby
+Datawow.project_key = <project-token>
+Datawow.document_verification.find_by(id: <either-id-or-custom_id>) # - To find task by specific ID.
+# - To either retrieve task as a list or find by specific ID.
+Datawow.document_verification.all(id: <either-id-or-custom_id>, page: <number-of-result-page>, per_page: <number-of-result-per-page>)
+```
 # Common function
 For every classes there are common functions to get list of data and find by ID. We're going to show you how to use it.
 

--- a/lib/datawow.rb
+++ b/lib/datawow.rb
@@ -10,6 +10,7 @@ require_relative 'datawow/models/images/image_photo_tags'
 require_relative 'datawow/models/images/image_choices'
 require_relative 'datawow/models/images/image_messages'
 require_relative 'datawow/models/images/nanameue_human'
+require_relative 'datawow/models/images/document_verification'
 require_relative 'datawow/models/predictions/predictors'
 
 require_relative 'datawow/models/texts/text_categories'
@@ -72,6 +73,10 @@ module Datawow
 
     def nanameue_human
       NanameueHuman.new
+    end
+
+    def document_verification
+      DocumentVerification.new
     end
   end
 end

--- a/lib/datawow/connector.rb
+++ b/lib/datawow/connector.rb
@@ -70,7 +70,7 @@ module Datawow
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
       request = build_request(uri)
-      request.set_form_data(data)
+      request.body = data.to_json
       response = https.request(request)
     end
 

--- a/lib/datawow/models/images/document_verification.rb
+++ b/lib/datawow/models/images/document_verification.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Datawow
+  # :nodoc:
+  class DocumentVerification
+    include Datawow::Models::Interface
+
+    attr_writer :project_key
+
+    def initialize(token = nil)
+      @project_key = token
+      @type = :image
+      @query_str = false
+
+      @path = 'images/document_verifications'
+    end
+  end
+end

--- a/test/datawow/image_document_verification_test.rb
+++ b/test/datawow/image_document_verification_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Datawow
+  class DocumentVerificationTest < TestBase
+    def test_all
+      stub_request(:get, IMAGE_DOCUMENT_VERIFICATION_URL)
+        .to_return(body: JSON.generate(image_document_verifications), status: 200)
+      response = model.all
+
+      assert_instance_of(Response, response)
+      assert_equal(200, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    def test_create
+      stub_request(:post, IMAGE_DOCUMENT_VERIFICATION_URL)
+        .to_return(body: JSON.generate(image_document_verification), status: 201)
+      response = model.create(options)
+
+      assert_instance_of(Response, response)
+      assert_equal(201, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    def test_find
+      stub_request(:get, "#{IMAGE_DOCUMENT_VERIFICATION_URL}/test")
+        .to_return(body: JSON.generate(image_document_verification), status: 200)
+      response = model.find_by(id: 'test')
+
+      assert_instance_of(Response, response)
+      assert_equal(200, response.status)
+      refute_nil(response.data)
+      refute_nil(response.meta)
+    end
+
+    private
+
+    def model
+      @model ||= DocumentVerification.new
+      @model.project_key = 'test'
+      @model
+    end
+  end
+end

--- a/test/fixtures/image_document_verification/all.json
+++ b/test/fixtures/image_document_verification/all.json
@@ -1,143 +1,143 @@
 {
-    "data": [
-        {
-            "id": "5c5cfb176e1157d3a56622fa",
-            "custom_id": null,
-            "status": "processed",
-            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
-            "postback": false,
-            "postback_method": "GET",
-            "project_id": 192,
-            "created_at": "2019-02-08T10:44:23.981+07:00",
-            "processed_at": "2019-02-08T10:44:36.350+07:00",
-            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
-            "infos": {
-                "type": {
-                    "value": "student_card",
-                    "valid": true
-                },
-                "dob": {
-                    "value": "91/11/28",
-                    "valid": true
-                }
-            },
-            "contributors": [
-                999999,
-                49
-            ]
+  "data": [
+    {
+      "id": "5c5cfb176e1157d3a56622fa",
+      "custom_id": null,
+      "status": "processed",
+      "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+      "postback": false,
+      "postback_method": "GET",
+      "project_id": 192,
+      "created_at": "2019-02-08T10:44:23.981+07:00",
+      "processed_at": "2019-02-08T10:44:36.350+07:00",
+      "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+      "infos": {
+        "type": {
+          "value": "student_card",
+          "valid": true
         },
-        {
-            "id": "5c5ce5bc6e1157b669f2ae5d",
-            "custom_id": null,
-            "status": "processed",
-            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
-            "postback": false,
-            "postback_method": "GET",
-            "project_id": 192,
-            "created_at": "2019-02-08T09:13:16.410+07:00",
-            "processed_at": "2019-02-08T10:34:26.088+07:00",
-            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
-            "infos": {
-                "type": {
-                    "value": "student_card",
-                    "valid": false
-                },
-                "dob": {
-                    "value": "91/11/28",
-                    "valid": true
-                }
-            },
-            "contributors": [
-                49,
-                999999
-            ]
-        },
-        {
-            "id": "5c5cdac56e1157a373e24da6",
-            "custom_id": null,
-            "status": "processed",
-            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
-            "postback": false,
-            "postback_method": "GET",
-            "project_id": 192,
-            "created_at": "2019-02-08T08:26:29.070+07:00",
-            "processed_at": "2019-02-08T08:29:18.893+07:00",
-            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
-            "infos": {
-                "type": {
-                    "value": "student_card",
-                    "valid": false
-                },
-                "dob": {
-                    "value": "91/11/28",
-                    "valid": false
-                }
-            },
-            "contributors": [
-                49,
-                999999
-            ]
-        },
-        {
-            "id": "5c5c02df6e1157989273f33e",
-            "custom_id": null,
-            "status": "processed",
-            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
-            "postback": false,
-            "postback_method": "GET",
-            "project_id": 192,
-            "created_at": "2019-02-07T17:05:19.586+07:00",
-            "processed_at": "2019-02-07T17:05:34.045+07:00",
-            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
-            "infos": {
-                "type": {
-                    "value": "student_card",
-                    "valid": false
-                },
-                "dob": {
-                    "value": "91/11/28",
-                    "valid": false
-                }
-            },
-            "contributors": [
-                999999,
-                49
-            ]
-        },
-        {
-            "id": "5c5c02796e1157989273f33b",
-            "custom_id": null,
-            "status": "processed",
-            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
-            "postback": false,
-            "postback_method": "GET",
-            "project_id": 192,
-            "created_at": "2019-02-07T17:03:37.214+07:00",
-            "processed_at": "2019-02-07T17:05:02.430+07:00",
-            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
-            "infos": {
-                "type": {
-                    "value": "student_card",
-                    "valid": true
-                },
-                "dob": {
-                    "value": "91/11/28",
-                    "valid": true
-                }
-            },
-            "contributors": [
-                999999,
-                49
-            ]
+        "dob": {
+          "value": "91/11/28",
+          "valid": true
         }
-    ],
-    "meta": {
-        "code": 200,
-        "message": "success",
-        "current_page": 1,
-        "next_page": -1,
-        "prev_page": -1,
-        "total_pages": 1,
-        "total_count": 5
+      },
+      "contributors": [
+        999999,
+        49
+      ]
+    },
+    {
+      "id": "5c5ce5bc6e1157b669f2ae5d",
+      "custom_id": null,
+      "status": "processed",
+      "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+      "postback": false,
+      "postback_method": "GET",
+      "project_id": 192,
+      "created_at": "2019-02-08T09:13:16.410+07:00",
+      "processed_at": "2019-02-08T10:34:26.088+07:00",
+      "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+      "infos": {
+        "type": {
+          "value": "student_card",
+          "valid": false
+        },
+        "dob": {
+          "value": "91/11/28",
+          "valid": true
+        }
+      },
+      "contributors": [
+        49,
+        999999
+      ]
+    },
+    {
+      "id": "5c5cdac56e1157a373e24da6",
+      "custom_id": null,
+      "status": "processed",
+      "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+      "postback": false,
+      "postback_method": "GET",
+      "project_id": 192,
+      "created_at": "2019-02-08T08:26:29.070+07:00",
+      "processed_at": "2019-02-08T08:29:18.893+07:00",
+      "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+      "infos": {
+        "type": {
+          "value": "student_card",
+          "valid": false
+        },
+        "dob": {
+          "value": "91/11/28",
+          "valid": false
+        }
+      },
+      "contributors": [
+        49,
+        999999
+      ]
+    },
+    {
+      "id": "5c5c02df6e1157989273f33e",
+      "custom_id": null,
+      "status": "processed",
+      "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+      "postback": false,
+      "postback_method": "GET",
+      "project_id": 192,
+      "created_at": "2019-02-07T17:05:19.586+07:00",
+      "processed_at": "2019-02-07T17:05:34.045+07:00",
+      "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+      "infos": {
+        "type": {
+          "value": "student_card",
+          "valid": false
+        },
+        "dob": {
+          "value": "91/11/28",
+          "valid": false
+        }
+      },
+      "contributors": [
+        999999,
+        49
+      ]
+    },
+    {
+      "id": "5c5c02796e1157989273f33b",
+      "custom_id": null,
+      "status": "processed",
+      "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+      "postback": false,
+      "postback_method": "GET",
+      "project_id": 192,
+      "created_at": "2019-02-07T17:03:37.214+07:00",
+      "processed_at": "2019-02-07T17:05:02.430+07:00",
+      "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+      "infos": {
+        "type": {
+          "value": "student_card",
+          "valid": true
+        },
+        "dob": {
+          "value": "91/11/28",
+          "valid": true
+        }
+      },
+      "contributors": [
+        999999,
+        49
+      ]
     }
+  ],
+  "meta": {
+    "code": 200,
+    "message": "success",
+    "current_page": 1,
+    "next_page": -1,
+    "prev_page": -1,
+    "total_pages": 1,
+    "total_count": 5
+  }
 }

--- a/test/fixtures/image_document_verification/all.json
+++ b/test/fixtures/image_document_verification/all.json
@@ -1,0 +1,143 @@
+{
+    "data": [
+        {
+            "id": "5c5cfb176e1157d3a56622fa",
+            "custom_id": null,
+            "status": "processed",
+            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+            "postback": false,
+            "postback_method": "GET",
+            "project_id": 192,
+            "created_at": "2019-02-08T10:44:23.981+07:00",
+            "processed_at": "2019-02-08T10:44:36.350+07:00",
+            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+            "infos": {
+                "type": {
+                    "value": "student_card",
+                    "valid": true
+                },
+                "dob": {
+                    "value": "91/11/28",
+                    "valid": true
+                }
+            },
+            "contributors": [
+                999999,
+                49
+            ]
+        },
+        {
+            "id": "5c5ce5bc6e1157b669f2ae5d",
+            "custom_id": null,
+            "status": "processed",
+            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+            "postback": false,
+            "postback_method": "GET",
+            "project_id": 192,
+            "created_at": "2019-02-08T09:13:16.410+07:00",
+            "processed_at": "2019-02-08T10:34:26.088+07:00",
+            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+            "infos": {
+                "type": {
+                    "value": "student_card",
+                    "valid": false
+                },
+                "dob": {
+                    "value": "91/11/28",
+                    "valid": true
+                }
+            },
+            "contributors": [
+                49,
+                999999
+            ]
+        },
+        {
+            "id": "5c5cdac56e1157a373e24da6",
+            "custom_id": null,
+            "status": "processed",
+            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+            "postback": false,
+            "postback_method": "GET",
+            "project_id": 192,
+            "created_at": "2019-02-08T08:26:29.070+07:00",
+            "processed_at": "2019-02-08T08:29:18.893+07:00",
+            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+            "infos": {
+                "type": {
+                    "value": "student_card",
+                    "valid": false
+                },
+                "dob": {
+                    "value": "91/11/28",
+                    "valid": false
+                }
+            },
+            "contributors": [
+                49,
+                999999
+            ]
+        },
+        {
+            "id": "5c5c02df6e1157989273f33e",
+            "custom_id": null,
+            "status": "processed",
+            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+            "postback": false,
+            "postback_method": "GET",
+            "project_id": 192,
+            "created_at": "2019-02-07T17:05:19.586+07:00",
+            "processed_at": "2019-02-07T17:05:34.045+07:00",
+            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+            "infos": {
+                "type": {
+                    "value": "student_card",
+                    "valid": false
+                },
+                "dob": {
+                    "value": "91/11/28",
+                    "valid": false
+                }
+            },
+            "contributors": [
+                999999,
+                49
+            ]
+        },
+        {
+            "id": "5c5c02796e1157989273f33b",
+            "custom_id": null,
+            "status": "processed",
+            "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+            "postback": false,
+            "postback_method": "GET",
+            "project_id": 192,
+            "created_at": "2019-02-07T17:03:37.214+07:00",
+            "processed_at": "2019-02-07T17:05:02.430+07:00",
+            "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+            "infos": {
+                "type": {
+                    "value": "student_card",
+                    "valid": true
+                },
+                "dob": {
+                    "value": "91/11/28",
+                    "valid": true
+                }
+            },
+            "contributors": [
+                999999,
+                49
+            ]
+        }
+    ],
+    "meta": {
+        "code": 200,
+        "message": "success",
+        "current_page": 1,
+        "next_page": -1,
+        "prev_page": -1,
+        "total_pages": 1,
+        "total_count": 5
+    }
+}

--- a/test/fixtures/image_document_verification/create.json
+++ b/test/fixtures/image_document_verification/create.json
@@ -1,0 +1,27 @@
+{
+    "data": {
+        "id": "5c5d399b6e11571af0b87911",
+        "custom_id": null,
+        "status": "unprocess",
+        "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+        "postback": false,
+        "postback_method": "GET",
+        "project_id": 192,
+        "created_at": "2019-02-08T15:11:07.116+07:00",
+        "processed_at": null,
+        "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+        "infos": {
+            "type": {
+                "value": "student_card"
+            },
+            "dob": {
+                "value": "91/11/28"
+            }
+        },
+        "contributors": []
+    },
+    "meta": {
+        "code": 201,
+        "message": "created success"
+    }
+}

--- a/test/fixtures/image_document_verification/create.json
+++ b/test/fixtures/image_document_verification/create.json
@@ -1,27 +1,27 @@
 {
-    "data": {
-        "id": "5c5d399b6e11571af0b87911",
-        "custom_id": null,
-        "status": "unprocess",
-        "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
-        "postback": false,
-        "postback_method": "GET",
-        "project_id": 192,
-        "created_at": "2019-02-08T15:11:07.116+07:00",
-        "processed_at": null,
-        "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
-        "infos": {
-            "type": {
-                "value": "student_card"
-            },
-            "dob": {
-                "value": "91/11/28"
-            }
-        },
-        "contributors": []
+  "data": {
+    "id": "5c5d399b6e11571af0b87911",
+    "custom_id": null,
+    "status": "unprocess",
+    "postback_url": "https://9a9fe5c0.ap.ngrok.io/api/v1/moderate/images/closed_questions",
+    "postback": false,
+    "postback_method": "GET",
+    "project_id": 192,
+    "created_at": "2019-02-08T15:11:07.116+07:00",
+    "processed_at": null,
+    "data": "https://assets-cdn.github.com/images/modules/open_graph/github-mark.png",
+    "infos": {
+      "type": {
+        "value": "student_card"
+      },
+      "dob": {
+        "value": "91/11/28"
+      }
     },
-    "meta": {
-        "code": 201,
-        "message": "created success"
-    }
+    "contributors": []
+  },
+  "meta": {
+    "code": 201,
+    "message": "created success"
+  }
 }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,48 +14,51 @@ class TestBase < Minitest::Test
               :image_photo_tags, :prediction, :predictions, :videos, :video,
               :text_categories, :text_category, :text_conversations, :text_conversation,
               :text_closed_questions, :text_closed_question, :nanameue_human, :nanameue_humans,
-              :text_ja, :text_jas
+              :text_ja, :text_jas, :image_document_verifications, :image_document_verification
 
-  IMAGE_CHOICES_URL          = 'https://kiyo-image.datawow.io/api/v1/images/choices'.freeze
-  IMAGE_CHOICE_URL           = 'https://kiyo-image.datawow.io/api/v1/images/choice'.freeze
+  IMAGE_CHOICES_URL = 'https://kiyo-image.datawow.io/api/v1/images/choices'.freeze
+  IMAGE_CHOICE_URL = 'https://kiyo-image.datawow.io/api/v1/images/choice'.freeze
   IMAGE_CLOSED_QUESTIONS_URL = 'https://kiyo-image.datawow.io/api/v1/images/closed_questions'.freeze
-  IMAGE_CLOSED_QUESTION_URL  = 'https://kiyo-image.datawow.io/api/v1/images/closed_question'.freeze
-  IMAGE_MESSAGES_URL         = 'https://kiyo-image.datawow.io/api/v1/images/messages'.freeze
-  IMAGE_MESSAGE_URL          = 'https://kiyo-image.datawow.io/api/v1/images/message'.freeze
-  IMAGE_PHOTO_TAGS           = 'https://kiyo-image.datawow.io/api/v1/images/photo_tags'.freeze
-  IMAGE_PHOTO_TAG            = 'https://kiyo-image.datawow.io/api/v1/images/photo_tag'.freeze
-  PREDICTIONS_URL            = 'https://kiyo-image.datawow.io/api/v1/prime/predictions'.freeze
-  IMAGE_URL                  = 'https://kiyo-image.datawow.io/api/v1/projects/images'.freeze
-  VIDEO_URL                  = 'https://kiyo-image.datawow.io/api/v1/videos/closed_questions'.freeze
-  NANAMEUE_HUMAN_URL         = 'https://kiyo-image.datawow.io/api/v1/jobs/nanameue/consensuses'.freeze
-  TEXT_CATEGORY_URL          = 'https://kiyo-text.datawow.io/api/v1/text/text_categories'.freeze
-  TEXT_CONVERSATION_URL      = 'https://kiyo-text.datawow.io/api/v1/text/text_conversations'.freeze
-  TEXT_CLOSED_QUESTION_URL   = 'https://kiyo-text.datawow.io/api/v1/text/text_closed_questions'.freeze
-  TEXT_JA_URL                = 'https://kiyo-text.datawow.io/api/v1/text_ai/text_ja'.freeze
+  IMAGE_CLOSED_QUESTION_URL = 'https://kiyo-image.datawow.io/api/v1/images/closed_question'.freeze
+  IMAGE_MESSAGES_URL = 'https://kiyo-image.datawow.io/api/v1/images/messages'.freeze
+  IMAGE_MESSAGE_URL = 'https://kiyo-image.datawow.io/api/v1/images/message'.freeze
+  IMAGE_PHOTO_TAGS = 'https://kiyo-image.datawow.io/api/v1/images/photo_tags'.freeze
+  IMAGE_PHOTO_TAG = 'https://kiyo-image.datawow.io/api/v1/images/photo_tag'.freeze
+  IMAGE_DOCUMENT_VERIFICATION_URL = 'https://kiyo-image.datawow.io/api/v1/images/document_verifications'.freeze
+  PREDICTIONS_URL = 'https://kiyo-image.datawow.io/api/v1/prime/predictions'.freeze
+  IMAGE_URL = 'https://kiyo-image.datawow.io/api/v1/projects/images'.freeze
+  VIDEO_URL = 'https://kiyo-image.datawow.io/api/v1/videos/closed_questions'.freeze
+  NANAMEUE_HUMAN_URL = 'https://kiyo-image.datawow.io/api/v1/jobs/nanameue/consensuses'.freeze
+  TEXT_CATEGORY_URL = 'https://kiyo-text.datawow.io/api/v1/text/text_categories'.freeze
+  TEXT_CONVERSATION_URL = 'https://kiyo-text.datawow.io/api/v1/text/text_conversations'.freeze
+  TEXT_CLOSED_QUESTION_URL = 'https://kiyo-text.datawow.io/api/v1/text/text_closed_questions'.freeze
+  TEXT_JA_URL = 'https://kiyo-text.datawow.io/api/v1/text_ai/text_ja'.freeze
 
   def setup
-    @image_choices          = FileReader.new('test/fixtures/image_choice/all.json').read_json
-    @image_choice           = FileReader.new('test/fixtures/image_choice/create.json').read_json
+    @image_choices = FileReader.new('test/fixtures/image_choice/all.json').read_json
+    @image_choice = FileReader.new('test/fixtures/image_choice/create.json').read_json
     @image_closed_questions = FileReader.new('test/fixtures/image_closed_question/all.json').read_json
-    @image_closed_question  = FileReader.new('test/fixtures/image_closed_question/create.json').read_json
-    @image_messages         = FileReader.new('test/fixtures/image_message/all.json').read_json
-    @image_message          = FileReader.new('test/fixtures/image_message/create.json').read_json
-    @image_photo_tags       = FileReader.new('test/fixtures/image_photo_tag/all.json').read_json
-    @image_photo_tag        = FileReader.new('test/fixtures/image_photo_tag/create.json').read_json
-    @predictions            = FileReader.new('test/fixtures/prediction/all.json').read_json
-    @prediction             = FileReader.new('test/fixtures/prediction/create.json').read_json
-    @videos                 = FileReader.new('test/fixtures/video_classification/all.json').read_json
-    @video                  = FileReader.new('test/fixtures/video_classification/create.json').read_json
-    @nanameue_human         = FileReader.new('test/fixtures/nanameue_human/create.json').read_json
-    @nanameue_humans        = FileReader.new('test/fixtures/nanameue_human/all.json').read_json
-    @text_category          = FileReader.new('test/fixtures/text_category/create.json').read_json
-    @text_categories        = FileReader.new('test/fixtures/text_category/all.json').read_json
-    @text_conversation      = FileReader.new('test/fixtures/text_conversation/create.json').read_json
-    @text_conversations     = FileReader.new('test/fixtures/text_conversation/all.json').read_json
-    @text_closed_question   = FileReader.new('test/fixtures/text_closed_question/create.json').read_json
-    @text_closed_questions  = FileReader.new('test/fixtures/text_closed_question/all.json').read_json
-    @text_ja                = FileReader.new('test/fixtures/text_ja/create.json').read_json
-    @text_jas               = FileReader.new('test/fixtures/text_ja/all.json').read_json
+    @image_closed_question = FileReader.new('test/fixtures/image_closed_question/create.json').read_json
+    @image_messages = FileReader.new('test/fixtures/image_message/all.json').read_json
+    @image_message = FileReader.new('test/fixtures/image_message/create.json').read_json
+    @image_photo_tags = FileReader.new('test/fixtures/image_photo_tag/all.json').read_json
+    @image_photo_tag = FileReader.new('test/fixtures/image_photo_tag/create.json').read_json
+    @image_document_verifications = FileReader.new('test/fixtures/image_document_verification/all.json').read_json
+    @image_document_verification = FileReader.new('test/fixtures/image_document_verification/create.json').read_json
+    @predictions = FileReader.new('test/fixtures/prediction/all.json').read_json
+    @prediction = FileReader.new('test/fixtures/prediction/create.json').read_json
+    @videos = FileReader.new('test/fixtures/video_classification/all.json').read_json
+    @video = FileReader.new('test/fixtures/video_classification/create.json').read_json
+    @nanameue_human = FileReader.new('test/fixtures/nanameue_human/create.json').read_json
+    @nanameue_humans = FileReader.new('test/fixtures/nanameue_human/all.json').read_json
+    @text_category = FileReader.new('test/fixtures/text_category/create.json').read_json
+    @text_categories = FileReader.new('test/fixtures/text_category/all.json').read_json
+    @text_conversation = FileReader.new('test/fixtures/text_conversation/create.json').read_json
+    @text_conversations = FileReader.new('test/fixtures/text_conversation/all.json').read_json
+    @text_closed_question = FileReader.new('test/fixtures/text_closed_question/create.json').read_json
+    @text_closed_questions = FileReader.new('test/fixtures/text_closed_question/all.json').read_json
+    @text_ja = FileReader.new('test/fixtures/text_ja/create.json').read_json
+    @text_jas = FileReader.new('test/fixtures/text_ja/all.json').read_json
     @options = {
       token: 'project token'
     }


### PR DESCRIPTION
This PR adds support Document Verification calls to Kiyo-Image.

## Changes
- Wrapped `GET` and `POST` method calls on `https://kiyo-image.datawow.io/api/v1/images/document_verifications`
- Add Unit tests.
- Tweaked how we bundle data in request. From as a form-data to application json body.
- Ignore tags file.
- Update how to use in Readme.